### PR TITLE
Add event start time into smart contract logic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ name: 'Smart contract tests'
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, feature/event-start-time ]
   pull_request:
     branches: [ main, dev ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ name: 'Smart contract tests'
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev, feature/event-start-time ]
+    branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sandbox included in this repository:
 
 ```shell
 cd src/test/sandbox
-./sandbox up dev
+./sandbox up
 
 # After sandbox loading, run the demo
 python src/contract.py

--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ Then, you will be able to run the demo script as explained in the previous subse
 
 ## How to: run tests over the smart contract
 
+### Make GitHub run the tests for you
+
+An automated GitHub Actions workflow is stored into `.github/workflows/tests.yml`. It contains two jobs, which will be
+run in parallel.
+\
+Both of them will:
+
+- set up an Ubuntu 22.04 environment
+- clone this repository and the sandbox submodule
+- install Python 3.10 and this project's dependencies
+- set up and run the sandbox
+
+Then, one will compile the smart contracts into TEAL code, while the other one will execute the tests using the Makefile
+in repository root.
+
+Both the jobs will upload some artifacts. The former will upload the TEAL code, while the latter will upload the test
+report. Artifacts are stored for 90 days.
+
+The workflow is executed on each push or pull request. However, you can request an execution manually, by going into
+the "Actions" tab, selecting "Smart contract tests" and clicking on "Run workflow". Then, you can monitor the execution
+and, at the end of the run, download the artifacts.
+
 ### Run tests using sandbox in dev configuration
 
 Tests are implemented using the `pytest` test framework for Python.

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -15,13 +15,13 @@ logger.setLevel(logging.DEBUG)
 
 
 # Add a "time" column to html output, to understand the tests execution order
-@pytest.mark.optionalhook
+@pytest.hookimpl(optionalhook=True)
 def pytest_html_results_table_header(cells):
     cells.insert(3, html.th('Time', class_='sortable time', col='time'))
     cells.pop()
 
 
-@pytest.mark.optionalhook
+@pytest.hookimpl(optionalhook=True)
 def pytest_html_results_table_row(report, cells):
     cells.insert(3, html.td(datetime.utcnow(), class_='col-time'))
     cells.pop()

--- a/src/test/reports/pytest_report.html
+++ b/src/test/reports/pytest_report.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
-    <title>Test Report</title>
+    <title>pytest_report.html</title>
     <link href="assets/style.css" rel="stylesheet" type="text/css"/></head>
   <body onLoad="init()">
     <script>/* This Source Code Form is subject to the terms of the Mozilla Public
@@ -70,9 +70,19 @@ function hideExtras(colresultElem) {
 }
 
 function showFilters() {
+    let visibleString = getQueryParameter('visible') || 'all';
+    visibleString = visibleString.toLowerCase();
+    const checkedItems = visibleString.split(',');
+
     const filterItems = document.getElementsByClassName('filter');
-    for (let i = 0; i < filterItems.length; i++)
+    for (let i = 0; i < filterItems.length; i++) {
         filterItems[i].hidden = false;
+
+        if (visibleString != 'all') {
+            filterItems[i].checked = checkedItems.includes(filterItems[i].getAttribute('data-test-result'));
+            filterTable(filterItems[i]);
+        }
+    }
 }
 
 function addCollapse() {
@@ -243,24 +253,24 @@ function filterTable(elem) { // eslint-disable-line no-unused-vars
 }
 </script>
     <h1>pytest_report.html</h1>
-    <p>Report generated on 26-Oct-2022 at 02:51:32 by <a href="https://pypi.python.org/pypi/pytest-html">pytest-html</a> v3.1.1</p>
+    <p>Report generated on 27-Oct-2022 at 00:51:50 by <a href="https://pypi.python.org/pypi/pytest-html">pytest-html</a> v3.2.0</p>
     <h2>Environment</h2>
     <table id="environment">
       <tr>
         <td>Packages</td>
-        <td>{"pluggy": "1.0.0", "py": "1.11.0", "pytest": "7.1.3"}</td></tr>
+        <td>{"pluggy": "1.0.0", "pytest": "7.2.0"}</td></tr>
       <tr>
         <td>Platform</td>
         <td>Linux-5.15.0-52-generic-x86_64-with-glibc2.35</td></tr>
       <tr>
         <td>Plugins</td>
-        <td>{"html": "3.1.1", "metadata": "2.0.2"}</td></tr>
+        <td>{"html": "3.2.0", "metadata": "2.0.3"}</td></tr>
       <tr>
         <td>Python</td>
         <td>3.10.6</td></tr></table>
     <h2>Summary</h2>
-    <p>28 tests ran in 144.59 seconds. </p>
-    <p class="filter" hidden="true">(Un)check the boxes to filter the results.</p><input checked="true" class="filter" data-test-result="passed" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="passed">28 passed</span>, <input checked="true" class="filter" data-test-result="skipped" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="skipped">0 skipped</span>, <input checked="true" class="filter" data-test-result="failed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="failed">0 failed</span>, <input checked="true" class="filter" data-test-result="error" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="error">0 errors</span>, <input checked="true" class="filter" data-test-result="xfailed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="xfailed">0 expected failures</span>, <input checked="true" class="filter" data-test-result="xpassed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="xpassed">0 unexpected passes</span>
+    <p>29 tests ran in 81.55 seconds. </p>
+    <p class="filter" hidden="true">(Un)check the boxes to filter the results.</p><input checked="true" class="filter" data-test-result="passed" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="passed">29 passed</span>, <input checked="true" class="filter" data-test-result="skipped" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="skipped">0 skipped</span>, <input checked="true" class="filter" data-test-result="failed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="failed">0 failed</span>, <input checked="true" class="filter" data-test-result="error" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="error">0 errors</span>, <input checked="true" class="filter" data-test-result="xfailed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="xfailed">0 expected failures</span>, <input checked="true" class="filter" data-test-result="xpassed" disabled="true" hidden="true" name="filter_checkbox" onChange="filterTable(this)" type="checkbox"/><span class="xpassed">0 unexpected passes</span>
     <h2>Results</h2>
     <table id="results-table">
       <thead id="results-table-head">
@@ -275,139 +285,106 @@ function filterTable(elem) { // eslint-disable-line no-unused-vars
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractPermissions::test_permissions_at_creation</td>
-          <td class="col-duration">80.88</td>
-          <td class="col-time">2022-10-26 00:51:32.355682</td></tr>
+          <td class="col-duration">3.07</td>
+          <td class="col-time">2022-10-26 22:51:50.296718</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> -----------------------------Captured stdout setup------------------------------ <br/>
-Stopping sandbox containers...
-Going to remove algorand-sandbox-indexer, algorand-sandbox-algod, algorand-sandbox-postgres
-
-Starting sandbox for: dev
-see sandbox.log for detailed progress, or use -v.
-
-[1A[0K
-[1A[0K [|] 
-[1A[0K [/] 
-[1A[0K [-] 
-[1A[0K [\] 
-[1A[0K [|] 
-[1A[0K
-[1A[0K* docker containers started!
-* waiting for services to initialize.
-the following did not start:
-* indexer node
-One or more services failed to start.
-Attempting to create 4 more accounts, funding them from B7AHA2KKRCI6D3ITN4LGC6JREN63UJBQA6IWAOB2XWEYI7JHHYJ343PNPQ ...
-Creating account 1 ...
-Sent 50000000 MicroAlgos from account B7AHA2KKRCI6D3ITN4LGC6JREN63UJBQA6IWAOB2XWEYI7JHHYJ343PNPQ to address BAHYRL5L2R47DT3GCKTMZCMTBXPRLJDTU5JIJQ7Q5REOCTK7JRTBMS2UC4, transaction ID: Q5GN345W67ZZLF52NG4RDKYC36MH3SZDWO4UHPDHQVZ6JCNQUB4A. Fee set to 1000
-Transaction Q5GN345W67ZZLF52NG4RDKYC36MH3SZDWO4UHPDHQVZ6JCNQUB4A committed in round 8
-Creating account 2 ...
-Sent 50000000 MicroAlgos from account B7AHA2KKRCI6D3ITN4LGC6JREN63UJBQA6IWAOB2XWEYI7JHHYJ343PNPQ to address 2GXQFSCEBUYR6OSBRM65ANGVUBMQ7LF7IDEGMCCRPTNZ2NILK4NYI75VAA, transaction ID: WFTX2TDHLUSJU2YXQ5SVGQW2FWCXHI5NV5K6L7ZA5PUZSCHXSKXA. Fee set to 1000
-Transaction WFTX2TDHLUSJU2YXQ5SVGQW2FWCXHI5NV5K6L7ZA5PUZSCHXSKXA committed in round 9
-Creating account 3 ...
-Sent 50000000 MicroAlgos from account B7AHA2KKRCI6D3ITN4LGC6JREN63UJBQA6IWAOB2XWEYI7JHHYJ343PNPQ to address PKSJHTVJ6XQDPYAV3DE63ESXUXINU5M7Z2DWHV7LKZJ3KUZQUZ3G52ADTQ, transaction ID: 4EFNJ5EGSNEVLYSCLARUORIOKVP53NALER242PL6FGTJWLBWNBFQ. Fee set to 1000
-Transaction 4EFNJ5EGSNEVLYSCLARUORIOKVP53NALER242PL6FGTJWLBWNBFQ committed in round 10
-Creating account 4 ...
-Sent 50000000 MicroAlgos from account B7AHA2KKRCI6D3ITN4LGC6JREN63UJBQA6IWAOB2XWEYI7JHHYJ343PNPQ to address CMRAH3DV74JVGBCOVNXNBBPFRVMVYHMDKIOLQGUVW5MQCEDBUBQ5GUNA6E, transaction ID: TPZBP22W5LOQDTAL7E6JCPAYOGE6YWPQMD4GUTXQKASYB4735DXQ. Fee set to 1000
-Transaction TPZBP22W5LOQDTAL7E6JCPAYOGE6YWPQMD4GUTXQKASYB4735DXQ committed in round 11
-[offline]	Unnamed-0	BAHYRL5L2R47DT3GCKTMZCMTBXPRLJDTU5JIJQ7Q5REOCTK7JRTBMS2UC4	50000000 microAlgos	*Default
-[online]	B7AHA2KKRCI6D3ITN4LGC6JREN63UJBQA6IWAOB2XWEYI7JHHYJ343PNPQ	B7AHA2KKRCI6D3ITN4LGC6JREN63UJBQA6IWAOB2XWEYI7JHHYJ343PNPQ	3999999799996000 microAlgos
-[offline]	Unnamed-3	CMRAH3DV74JVGBCOVNXNBBPFRVMVYHMDKIOLQGUVW5MQCEDBUBQ5GUNA6E	50000000 microAlgos
-[online]	EAXZSWIOLMSTJ3OZLZJ32YUIOVKRXRLHTFEOKMCSHDFDADPNQFJDMJBWDM	EAXZSWIOLMSTJ3OZLZJ32YUIOVKRXRLHTFEOKMCSHDFDADPNQFJDMJBWDM	1999999998854000 microAlgos	[created app IDs: 1]	[opted in app IDs: 1]
-[offline]	Unnamed-2	PKSJHTVJ6XQDPYAV3DE63ESXUXINU5M7Z2DWHV7LKZJ3KUZQUZ3G52ADTQ	50000000 microAlgos
-[online]	U7CIUZR5YKR7TEXJ2Q5R5SXR7L5QLNIVGDS5IUYRADIIPMNTLUD2OK3NX4	U7CIUZR5YKR7TEXJ2Q5R5SXR7L5QLNIVGDS5IUYRADIIPMNTLUD2OK3NX4	3999999999857000 microAlgos	[opted in app IDs: 1]
-[offline]	Unnamed-1	2GXQFSCEBUYR6OSBRM65ANGVUBMQ7LF7IDEGMCCRPTNZ2NILK4NYI75VAA	50000000 microAlgos
-<br/> -----------------------------Captured stderr setup------------------------------ <br/>[conftest.py:73 -        sandbox_setup() ] --sandbox argument provided -&gt; starting the sandbox...
-Stopping algorand-sandbox-algod    ... 
-Stopping algorand-sandbox-postgres ... 
-Stopping algorand-sandbox-postgres ... done
-Stopping algorand-sandbox-algod    ... done
-Removing algorand-sandbox-indexer  ... 
-Removing algorand-sandbox-algod    ... 
-Removing algorand-sandbox-postgres ... 
-Removing algorand-sandbox-indexer  ... done
-Removing algorand-sandbox-postgres ... done
-Removing algorand-sandbox-algod    ... done
-[test_contract.py:222 -          debug_print() ] Class configuration:
-{&#x27;event_end_since_test_start_s&#x27;: 2,
+            <div class="log"> -----------------------------Captured stderr setup------------------------------ <br/>[conftest.py:79 -        sandbox_setup() ] --sandbox argument not provided -&gt; skipping sandbox setup...
+[test_contract.py:248 -          debug_print() ] Class configuration:
+{&#x27;event_end_since_test_start_s&#x27;: 10,
+ &#x27;event_start_since_test_start_s&#x27;: 5,
  &#x27;payout_time_s&#x27;: 3,
- &#x27;session_start_s&#x27;: 1666745347.8061175}
-[test_contract.py:192 -             app_addr() ] Creating the application...
-[test_contract.py:194 -             app_addr() ] Created app with id: 14 and address: LQRH3CW2MZGN2TOCTVBOOJVS42BZZKJ5PML6BPABTU4M7QULXOQNSZDO6E in tx: GEJ2ZWP4O3OJKOPB2D52QV23JTIGZLELE4IUSDDVB5SZBD3BNMCQ
-[test_contract.py:196 -             app_addr() ] Setting up the application...
-[test_contract.py:204 -             app_addr() ] Setup requested with transaction: G5VVBYOYOV5GYRG62A6UNSFIBV5DUI7SRJCRWA55UXFUPXL4IE4Q.
-Current app state: {&#x27;counter_opt_2&#x27;: 0, &#x27;oracle_addr&#x27;: &#x27;a7c48a663dc2a3f992e9d43b1ecaf1fafb05b51530e5d4531100d087b1b35d07&#x27;, &#x27;counter_opt_0&#x27;: 0, &#x27;bet_amount&#x27;: 140000, &#x27;event_timestamp&#x27;: 1666745429, &#x27;event_result&#x27;: 99, &#x27;payout_time_window_s&#x27;: 3, &#x27;winning_count&#x27;: 0, &#x27;stake_amount&#x27;: 0, &#x27;counter_opt_1&#x27;: 0, &#x27;manager&#x27;: &#x27;d1af02c8440d311f3a418b3dd034d5a0590facbf40c86608517cdb9d350b571b&#x27;, &#x27;winning_payout&#x27;: 0}
-[test_contract.py:210 -             app_addr() ] Funded LQRH3CW2MZGN2TOCTVBOOJVS42BZZKJ5PML6BPABTU4M7QULXOQNSZDO6E with 200000microAlgos
-<br/> -------------------------------Captured log setup------------------------------- <br/>INFO     test.conftest:conftest.py:73 --sandbox argument provided -&gt; starting the sandbox...
-DEBUG    test.conftest:test_contract.py:222 Class configuration:
-{&#x27;event_end_since_test_start_s&#x27;: 2,
+ &#x27;session_start_s&#x27;: 1666824628.7871842}
+[test_contract.py:217 -             app_addr() ] Creating the application...
+[test_contract.py:219 -             app_addr() ] Created app with id: 214 and address: 5OOC7VWU36BB7S5JL4ERNWMB3M76TSBADARFD5ZRA7MU3HY6I3D4RS7ETU in tx: LEFWOYH6HWGIGEJNU5VY3IGCBOKTBEGWDBBXBTRMWMCQ3KJ3LQCA
+[test_contract.py:221 -             app_addr() ] Setting up the application...
+[test_contract.py:230 -             app_addr() ] Setup requested with transaction: O5ICJUU4AUMLAO6KTDSHT4BUK677OWYWBVVYCFKTOAQOCALRWFAA.
+Current app state: {&#x27;bet_amount&#x27;: 140000, &#x27;oracle_addr&#x27;: &#x27;f4f6dbe4b6ef267f530ae9e1f28462d65940b5f19717d9a4585a65dacc93d5e2&#x27;, &#x27;event_result&#x27;: 99, &#x27;event_end_timestamp&#x27;: 1666824640, &#x27;counter_opt_1&#x27;: 0, &#x27;payout_time_window_s&#x27;: 3, &#x27;counter_opt_2&#x27;: 0, &#x27;manager&#x27;: &#x27;fde998315d5a659f9e6ff1e73b71842c8fee900e15d32d515d029efdb85b49eb&#x27;, &#x27;stake_amount&#x27;: 0, &#x27;event_start_timestamp&#x27;: 1666824635, &#x27;winning_count&#x27;: 0, &#x27;counter_opt_0&#x27;: 0, &#x27;winning_payout&#x27;: 0}
+[test_contract.py:236 -             app_addr() ] Funded 5OOC7VWU36BB7S5JL4ERNWMB3M76TSBADARFD5ZRA7MU3HY6I3D4RS7ETU with 200000microAlgos
+<br/> -------------------------------Captured log setup------------------------------- <br/>INFO     test.conftest:conftest.py:79 --sandbox argument not provided -&gt; skipping sandbox setup...
+DEBUG    test.conftest:test_contract.py:248 Class configuration:
+{&#x27;event_end_since_test_start_s&#x27;: 10,
+ &#x27;event_start_since_test_start_s&#x27;: 5,
  &#x27;payout_time_s&#x27;: 3,
- &#x27;session_start_s&#x27;: 1666745347.8061175}
-DEBUG    test.conftest:test_contract.py:192 Creating the application...
-DEBUG    test.conftest:test_contract.py:194 Created app with id: 14 and address: LQRH3CW2MZGN2TOCTVBOOJVS42BZZKJ5PML6BPABTU4M7QULXOQNSZDO6E in tx: GEJ2ZWP4O3OJKOPB2D52QV23JTIGZLELE4IUSDDVB5SZBD3BNMCQ
-DEBUG    test.conftest:test_contract.py:196 Setting up the application...
-DEBUG    test.conftest:test_contract.py:204 Setup requested with transaction: G5VVBYOYOV5GYRG62A6UNSFIBV5DUI7SRJCRWA55UXFUPXL4IE4Q.
-Current app state: {&#x27;counter_opt_2&#x27;: 0, &#x27;oracle_addr&#x27;: &#x27;a7c48a663dc2a3f992e9d43b1ecaf1fafb05b51530e5d4531100d087b1b35d07&#x27;, &#x27;counter_opt_0&#x27;: 0, &#x27;bet_amount&#x27;: 140000, &#x27;event_timestamp&#x27;: 1666745429, &#x27;event_result&#x27;: 99, &#x27;payout_time_window_s&#x27;: 3, &#x27;winning_count&#x27;: 0, &#x27;stake_amount&#x27;: 0, &#x27;counter_opt_1&#x27;: 0, &#x27;manager&#x27;: &#x27;d1af02c8440d311f3a418b3dd034d5a0590facbf40c86608517cdb9d350b571b&#x27;, &#x27;winning_payout&#x27;: 0}
-DEBUG    test.conftest:test_contract.py:210 Funded LQRH3CW2MZGN2TOCTVBOOJVS42BZZKJ5PML6BPABTU4M7QULXOQNSZDO6E with 200000microAlgos<br/></div></td></tr></tbody>
+ &#x27;session_start_s&#x27;: 1666824628.7871842}
+DEBUG    test.conftest:test_contract.py:217 Creating the application...
+DEBUG    test.conftest:test_contract.py:219 Created app with id: 214 and address: 5OOC7VWU36BB7S5JL4ERNWMB3M76TSBADARFD5ZRA7MU3HY6I3D4RS7ETU in tx: LEFWOYH6HWGIGEJNU5VY3IGCBOKTBEGWDBBXBTRMWMCQ3KJ3LQCA
+DEBUG    test.conftest:test_contract.py:221 Setting up the application...
+DEBUG    test.conftest:test_contract.py:230 Setup requested with transaction: O5ICJUU4AUMLAO6KTDSHT4BUK677OWYWBVVYCFKTOAQOCALRWFAA.
+Current app state: {&#x27;bet_amount&#x27;: 140000, &#x27;oracle_addr&#x27;: &#x27;f4f6dbe4b6ef267f530ae9e1f28462d65940b5f19717d9a4585a65dacc93d5e2&#x27;, &#x27;event_result&#x27;: 99, &#x27;event_end_timestamp&#x27;: 1666824640, &#x27;counter_opt_1&#x27;: 0, &#x27;payout_time_window_s&#x27;: 3, &#x27;counter_opt_2&#x27;: 0, &#x27;manager&#x27;: &#x27;fde998315d5a659f9e6ff1e73b71842c8fee900e15d32d515d029efdb85b49eb&#x27;, &#x27;stake_amount&#x27;: 0, &#x27;event_start_timestamp&#x27;: 1666824635, &#x27;winning_count&#x27;: 0, &#x27;counter_opt_0&#x27;: 0, &#x27;winning_payout&#x27;: 0}
+DEBUG    test.conftest:test_contract.py:236 Funded 5OOC7VWU36BB7S5JL4ERNWMB3M76TSBADARFD5ZRA7MU3HY6I3D4RS7ETU with 200000microAlgos<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractPermissions::test_opt_in_creator</td>
-          <td class="col-duration">0.37</td>
-          <td class="col-time">2022-10-26 00:51:32.355782</td></tr>
+          <td class="col-duration">0.28</td>
+          <td class="col-time">2022-10-26 22:51:50.296815</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:248 -  test_opt_in_creator() ] Try calling bet() without opting in...
-[test_contract.py:263 -  test_opt_in_creator() ] Opting-in accounts...
-[test_contract.py:267 -  test_opt_in_creator() ] Trying same transaction after opt-in...
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:248 Try calling bet() without opting in...
-DEBUG    test.conftest:test_contract.py:263 Opting-in accounts...
-DEBUG    test.conftest:test_contract.py:267 Trying same transaction after opt-in...<br/></div></td></tr></tbody>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:274 -  test_opt_in_creator() ] Try calling bet() without opting in...
+[test_contract.py:289 -  test_opt_in_creator() ] Opting-in accounts...
+[test_contract.py:293 -  test_opt_in_creator() ] Trying same transaction after opt-in...
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:274 Try calling bet() without opting in...
+DEBUG    test.conftest:test_contract.py:289 Opting-in accounts...
+DEBUG    test.conftest:test_contract.py:293 Trying same transaction after opt-in...<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractPermissions::test_opt_in_participant</td>
-          <td class="col-duration">0.36</td>
-          <td class="col-time">2022-10-26 00:51:32.355843</td></tr>
+          <td class="col-duration">0.23</td>
+          <td class="col-time">2022-10-26 22:51:50.296875</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:286 - test_opt_in_participant() ] Try calling bet() without opting in...
-[test_contract.py:301 - test_opt_in_participant() ] Opting-in accounts...
-[test_contract.py:305 - test_opt_in_participant() ] Trying same transaction after opt-in...
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:286 Try calling bet() without opting in...
-DEBUG    test.conftest:test_contract.py:301 Opting-in accounts...
-DEBUG    test.conftest:test_contract.py:305 Trying same transaction after opt-in...<br/></div></td></tr></tbody>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:312 - test_opt_in_participant() ] Try calling bet() without opting in...
+[test_contract.py:327 - test_opt_in_participant() ] Opting-in accounts...
+[test_contract.py:331 - test_opt_in_participant() ] Trying same transaction after opt-in...
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:312 Try calling bet() without opting in...
+DEBUG    test.conftest:test_contract.py:327 Opting-in accounts...
+DEBUG    test.conftest:test_contract.py:331 Trying same transaction after opt-in...<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractPermissions::test_opt_in_oracle</td>
-          <td class="col-duration">0.36</td>
-          <td class="col-time">2022-10-26 00:51:32.355900</td></tr>
+          <td class="col-duration">0.32</td>
+          <td class="col-time">2022-10-26 22:51:50.296930</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:324 -   test_opt_in_oracle() ] Try calling bet() without opting in...
-[test_contract.py:339 -   test_opt_in_oracle() ] Opting-in accounts...
-[test_contract.py:343 -   test_opt_in_oracle() ] Trying same transaction after opt-in...
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:324 Try calling bet() without opting in...
-DEBUG    test.conftest:test_contract.py:339 Opting-in accounts...
-DEBUG    test.conftest:test_contract.py:343 Trying same transaction after opt-in...<br/></div></td></tr></tbody>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:350 -   test_opt_in_oracle() ] Try calling bet() without opting in...
+[test_contract.py:365 -   test_opt_in_oracle() ] Opting-in accounts...
+[test_contract.py:369 -   test_opt_in_oracle() ] Trying same transaction after opt-in...
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:350 Try calling bet() without opting in...
+DEBUG    test.conftest:test_contract.py:365 Opting-in accounts...
+DEBUG    test.conftest:test_contract.py:369 Trying same transaction after opt-in...<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractPermissions::test_set_result_from_non_authorized</td>
-          <td class="col-duration">4.37</td>
-          <td class="col-time">2022-10-26 00:51:32.355952</td></tr>
+          <td class="col-duration">12.36</td>
+          <td class="col-time">2022-10-26 22:51:50.296986</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.<br/></div></td></tr></tbody>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractPermissions::test_delete_from_non_authorized</td>
-          <td class="col-duration">3.23</td>
-          <td class="col-time">2022-10-26 00:51:32.355995</td></tr>
+          <td class="col-duration">3.28</td>
+          <td class="col-time">2022-10-26 22:51:50.297030</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -415,46 +392,48 @@ DEBUG    test.conftest:test_contract.py:343 Trying same transaction after opt-in
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractPermissions::test_app_deletion_and_close_out</td>
-          <td class="col-duration">3.27</td>
-          <td class="col-time">2022-10-26 00:51:32.356046</td></tr>
+          <td class="col-duration">3.36</td>
+          <td class="col-time">2022-10-26 22:51:50.297080</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:377 - test_app_deletion_and_close_out() ] App deleted with TX 3WYJIRZASXHZW2DGQOCAPRPEIGYZMPENOTKZGXTY53H2NBCUZEPQ
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:377 App deleted with TX 3WYJIRZASXHZW2DGQOCAPRPEIGYZMPENOTKZGXTY53H2NBCUZEPQ<br/></div></td></tr></tbody>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:403 - test_app_deletion_and_close_out() ] App deleted with TX BQNK6SEDFIMROWWH5OSSNEHUF5GNNQMXKOEJDDMYDBS6ADBH3FTQ
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:403 App deleted with TX BQNK6SEDFIMROWWH5OSSNEHUF5GNNQMXKOEJDDMYDBS6ADBH3FTQ<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_participants_opt_in</td>
-          <td class="col-duration">3.82</td>
-          <td class="col-time">2022-10-26 00:51:32.356104</td></tr>
+          <td class="col-duration">3.54</td>
+          <td class="col-time">2022-10-26 22:51:50.297139</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> -----------------------------Captured stderr setup------------------------------ <br/>[test_contract.py:222 -          debug_print() ] Class configuration:
+            <div class="log"> -----------------------------Captured stderr setup------------------------------ <br/>[test_contract.py:248 -          debug_print() ] Class configuration:
 {&#x27;event_end_since_test_start_s&#x27;: 15,
+ &#x27;event_start_since_test_start_s&#x27;: 5,
  &#x27;payout_time_s&#x27;: 15,
- &#x27;session_start_s&#x27;: 1666745347.8061981}
-[test_contract.py:192 -             app_addr() ] Creating the application...
-[test_contract.py:194 -             app_addr() ] Created app with id: 33 and address: TBXCKFOFZWMTTB3MJOZGECCJDIGIJW2E3QTLJV2SP5GOGEPTOZY4UH562M in tx: R23MPGOJEUAHQCYYRNKO3A3VA4QPPVNNIE5ZKFZTTI47TGIL62FA
-[test_contract.py:196 -             app_addr() ] Setting up the application...
-[test_contract.py:204 -             app_addr() ] Setup requested with transaction: Q53CXKIIDLZX32UZG7KTNSOQ4YWUXSGE3WXYI3MFPYE66ACKZHLQ.
-Current app state: {&#x27;counter_opt_0&#x27;: 0, &#x27;event_result&#x27;: 99, &#x27;bet_amount&#x27;: 140000, &#x27;counter_opt_1&#x27;: 0, &#x27;oracle_addr&#x27;: &#x27;a7c48a663dc2a3f992e9d43b1ecaf1fafb05b51530e5d4531100d087b1b35d07&#x27;, &#x27;winning_count&#x27;: 0, &#x27;manager&#x27;: &#x27;d1af02c8440d311f3a418b3dd034d5a0590facbf40c86608517cdb9d350b571b&#x27;, &#x27;event_timestamp&#x27;: 1666745457, &#x27;payout_time_window_s&#x27;: 15, &#x27;counter_opt_2&#x27;: 0, &#x27;stake_amount&#x27;: 0, &#x27;winning_payout&#x27;: 0}
-[test_contract.py:210 -             app_addr() ] Funded TBXCKFOFZWMTTB3MJOZGECCJDIGIJW2E3QTLJV2SP5GOGEPTOZY4UH562M with 200000microAlgos
-<br/> -------------------------------Captured log setup------------------------------- <br/>DEBUG    test.conftest:test_contract.py:222 Class configuration:
+ &#x27;session_start_s&#x27;: 1666824628.7875445}
+[test_contract.py:217 -             app_addr() ] Creating the application...
+[test_contract.py:219 -             app_addr() ] Created app with id: 240 and address: KDN2FJPFCK2PI37UTDEI5T5ZTF3PGPLYLOTVFDOWIFBETGBYWKM2XSFUJE in tx: AXPDGDFPGXJZ4G3B7NMQKESP26CPB2LE7XLQOI3WWBGAIKEGHPEQ
+[test_contract.py:221 -             app_addr() ] Setting up the application...
+[test_contract.py:230 -             app_addr() ] Setup requested with transaction: P4FUVSPUWY2A3OTHTUX364F6U6RVS2VFUJ2TN4GSWIOG53OYPQVQ.
+Current app state: {&#x27;bet_amount&#x27;: 140000, &#x27;counter_opt_1&#x27;: 0, &#x27;counter_opt_0&#x27;: 0, &#x27;event_result&#x27;: 99, &#x27;stake_amount&#x27;: 0, &#x27;winning_payout&#x27;: 0, &#x27;counter_opt_2&#x27;: 0, &#x27;payout_time_window_s&#x27;: 15, &#x27;oracle_addr&#x27;: &#x27;f4f6dbe4b6ef267f530ae9e1f28462d65940b5f19717d9a4585a65dacc93d5e2&#x27;, &#x27;event_end_timestamp&#x27;: 1666824668, &#x27;event_start_timestamp&#x27;: 1666824658, &#x27;manager&#x27;: &#x27;fde998315d5a659f9e6ff1e73b71842c8fee900e15d32d515d029efdb85b49eb&#x27;, &#x27;winning_count&#x27;: 0}
+[test_contract.py:236 -             app_addr() ] Funded KDN2FJPFCK2PI37UTDEI5T5ZTF3PGPLYLOTVFDOWIFBETGBYWKM2XSFUJE with 200000microAlgos
+<br/> -------------------------------Captured log setup------------------------------- <br/>DEBUG    test.conftest:test_contract.py:248 Class configuration:
 {&#x27;event_end_since_test_start_s&#x27;: 15,
+ &#x27;event_start_since_test_start_s&#x27;: 5,
  &#x27;payout_time_s&#x27;: 15,
- &#x27;session_start_s&#x27;: 1666745347.8061981}
-DEBUG    test.conftest:test_contract.py:192 Creating the application...
-DEBUG    test.conftest:test_contract.py:194 Created app with id: 33 and address: TBXCKFOFZWMTTB3MJOZGECCJDIGIJW2E3QTLJV2SP5GOGEPTOZY4UH562M in tx: R23MPGOJEUAHQCYYRNKO3A3VA4QPPVNNIE5ZKFZTTI47TGIL62FA
-DEBUG    test.conftest:test_contract.py:196 Setting up the application...
-DEBUG    test.conftest:test_contract.py:204 Setup requested with transaction: Q53CXKIIDLZX32UZG7KTNSOQ4YWUXSGE3WXYI3MFPYE66ACKZHLQ.
-Current app state: {&#x27;counter_opt_0&#x27;: 0, &#x27;event_result&#x27;: 99, &#x27;bet_amount&#x27;: 140000, &#x27;counter_opt_1&#x27;: 0, &#x27;oracle_addr&#x27;: &#x27;a7c48a663dc2a3f992e9d43b1ecaf1fafb05b51530e5d4531100d087b1b35d07&#x27;, &#x27;winning_count&#x27;: 0, &#x27;manager&#x27;: &#x27;d1af02c8440d311f3a418b3dd034d5a0590facbf40c86608517cdb9d350b571b&#x27;, &#x27;event_timestamp&#x27;: 1666745457, &#x27;payout_time_window_s&#x27;: 15, &#x27;counter_opt_2&#x27;: 0, &#x27;stake_amount&#x27;: 0, &#x27;winning_payout&#x27;: 0}
-DEBUG    test.conftest:test_contract.py:210 Funded TBXCKFOFZWMTTB3MJOZGECCJDIGIJW2E3QTLJV2SP5GOGEPTOZY4UH562M with 200000microAlgos<br/></div></td></tr></tbody>
+ &#x27;session_start_s&#x27;: 1666824628.7875445}
+DEBUG    test.conftest:test_contract.py:217 Creating the application...
+DEBUG    test.conftest:test_contract.py:219 Created app with id: 240 and address: KDN2FJPFCK2PI37UTDEI5T5ZTF3PGPLYLOTVFDOWIFBETGBYWKM2XSFUJE in tx: AXPDGDFPGXJZ4G3B7NMQKESP26CPB2LE7XLQOI3WWBGAIKEGHPEQ
+DEBUG    test.conftest:test_contract.py:221 Setting up the application...
+DEBUG    test.conftest:test_contract.py:230 Setup requested with transaction: P4FUVSPUWY2A3OTHTUX364F6U6RVS2VFUJ2TN4GSWIOG53OYPQVQ.
+Current app state: {&#x27;bet_amount&#x27;: 140000, &#x27;counter_opt_1&#x27;: 0, &#x27;counter_opt_0&#x27;: 0, &#x27;event_result&#x27;: 99, &#x27;stake_amount&#x27;: 0, &#x27;winning_payout&#x27;: 0, &#x27;counter_opt_2&#x27;: 0, &#x27;payout_time_window_s&#x27;: 15, &#x27;oracle_addr&#x27;: &#x27;f4f6dbe4b6ef267f530ae9e1f28462d65940b5f19717d9a4585a65dacc93d5e2&#x27;, &#x27;event_end_timestamp&#x27;: 1666824668, &#x27;event_start_timestamp&#x27;: 1666824658, &#x27;manager&#x27;: &#x27;fde998315d5a659f9e6ff1e73b71842c8fee900e15d32d515d029efdb85b49eb&#x27;, &#x27;winning_count&#x27;: 0}
+DEBUG    test.conftest:test_contract.py:236 Funded KDN2FJPFCK2PI37UTDEI5T5ZTF3PGPLYLOTVFDOWIFBETGBYWKM2XSFUJE with 200000microAlgos<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_make_bet_wrong_stack</td>
-          <td class="col-duration">0.26</td>
-          <td class="col-time">2022-10-26 00:51:32.356146</td></tr>
+          <td class="col-duration">0.09</td>
+          <td class="col-time">2022-10-26 22:51:50.297182</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -462,8 +441,8 @@ DEBUG    test.conftest:test_contract.py:210 Funded TBXCKFOFZWMTTB3MJOZGECCJDIGIJ
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_make_bet_wrong_option</td>
-          <td class="col-duration">0.22</td>
-          <td class="col-time">2022-10-26 00:51:32.356187</td></tr>
+          <td class="col-duration">0.09</td>
+          <td class="col-time">2022-10-26 22:51:50.297228</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -471,8 +450,8 @@ DEBUG    test.conftest:test_contract.py:210 Funded TBXCKFOFZWMTTB3MJOZGECCJDIGIJ
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_make_bets</td>
-          <td class="col-duration">0.83</td>
-          <td class="col-time">2022-10-26 00:51:32.356226</td></tr>
+          <td class="col-duration">0.76</td>
+          <td class="col-time">2022-10-26 22:51:50.297268</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -480,17 +459,31 @@ DEBUG    test.conftest:test_contract.py:210 Funded TBXCKFOFZWMTTB3MJOZGECCJDIGIJ
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_make_bets_twice</td>
-          <td class="col-duration">0.09</td>
-          <td class="col-time">2022-10-26 00:51:32.356265</td></tr>
+          <td class="col-duration">0.14</td>
+          <td class="col-time">2022-10-26 22:51:50.297307</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
+          <td class="col-name">test_contract.py::TestContractFlow::test_make_bets_after_event_start</td>
+          <td class="col-duration">6.91</td>
+          <td class="col-time">2022-10-26 22:51:50.297359</td></tr>
+        <tr>
+          <td class="extra" colspan="4">
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:92 - _safe_wait_to_event_end() ] Waiting for a time in which the event is already ended.
+[test_contract.py:92 - _safe_wait_to_event_end() ] Waiting for a time in which the event is already ended.
+[test_contract.py:92 - _safe_wait_to_event_end() ] Waiting for a time in which the event is already ended.
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which the event is already ended.
+DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which the event is already ended.
+DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which the event is already ended.<br/></div></td></tr></tbody>
+      <tbody class="passed results-table-row">
+        <tr>
+          <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_request_payout_before_event_end</td>
           <td class="col-duration">0.00</td>
-          <td class="col-time">2022-10-26 00:51:32.356304</td></tr>
+          <td class="col-time">2022-10-26 22:51:50.297400</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -499,7 +492,7 @@ DEBUG    test.conftest:test_contract.py:210 Funded TBXCKFOFZWMTTB3MJOZGECCJDIGIJ
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_oracle_set_result_before_event_end</td>
           <td class="col-duration">0.00</td>
-          <td class="col-time">2022-10-26 00:51:32.356344</td></tr>
+          <td class="col-time">2022-10-26 22:51:50.297439</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -507,8 +500,8 @@ DEBUG    test.conftest:test_contract.py:210 Funded TBXCKFOFZWMTTB3MJOZGECCJDIGIJ
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_request_payout_before_event_results</td>
-          <td class="col-duration">0.00</td>
-          <td class="col-time">2022-10-26 00:51:32.356383</td></tr>
+          <td class="col-duration">0.05</td>
+          <td class="col-time">2022-10-26 22:51:50.297522</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -516,40 +509,28 @@ DEBUG    test.conftest:test_contract.py:210 Funded TBXCKFOFZWMTTB3MJOZGECCJDIGIJ
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_oracle_set_result_after_event_end</td>
-          <td class="col-duration">16.94</td>
-          <td class="col-time">2022-10-26 00:51:32.356483</td></tr>
+          <td class="col-duration">10.74</td>
+          <td class="col-time">2022-10-26 22:51:50.297576</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.
-DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.<br/></div></td></tr></tbody>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_request_payout_looser</td>
-          <td class="col-duration">0.04</td>
-          <td class="col-time">2022-10-26 00:51:32.356527</td></tr>
+          <td class="col-duration">0.00</td>
+          <td class="col-time">2022-10-26 22:51:50.297617</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -557,8 +538,8 @@ DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_request_payout_winners</td>
-          <td class="col-duration">0.32</td>
-          <td class="col-time">2022-10-26 00:51:32.356568</td></tr>
+          <td class="col-duration">0.36</td>
+          <td class="col-time">2022-10-26 22:51:50.297657</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -567,7 +548,7 @@ DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_request_payout_winners_again</td>
           <td class="col-duration">0.05</td>
-          <td class="col-time">2022-10-26 00:51:32.356608</td></tr>
+          <td class="col-time">2022-10-26 22:51:50.297697</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -576,7 +557,7 @@ DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_request_deletion_before_payout_time</td>
           <td class="col-duration">0.00</td>
-          <td class="col-time">2022-10-26 00:51:32.356648</td></tr>
+          <td class="col-time">2022-10-26 22:51:50.297737</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -584,64 +565,64 @@ DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractFlow::test_request_deletion_after_payout_time</td>
-          <td class="col-duration">14.79</td>
-          <td class="col-time">2022-10-26 00:51:32.356703</td></tr>
+          <td class="col-duration">13.58</td>
+          <td class="col-time">2022-10-26 22:51:50.297792</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-[test_contract.py:92 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.
-DEBUG    test.conftest:test_contract.py:92 Waiting for a time in which app deletion is allowed.<br/></div></td></tr></tbody>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+[test_contract.py:117 - _safe_wait_to_delete() ] Waiting for a time in which app deletion is allowed.
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.
+DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.
+DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.
+DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.
+DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.
+DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.
+DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.
+DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.
+DEBUG    test.conftest:test_contract.py:117 Waiting for a time in which app deletion is allowed.<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractNoWinners::test_participants_opt_in</td>
           <td class="col-duration">3.39</td>
-          <td class="col-time">2022-10-26 00:51:32.356760</td></tr>
+          <td class="col-time">2022-10-26 22:51:50.297850</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> -----------------------------Captured stderr setup------------------------------ <br/>[test_contract.py:222 -          debug_print() ] Class configuration:
-{&#x27;event_end_since_test_start_s&#x27;: 2,
+            <div class="log"> -----------------------------Captured stderr setup------------------------------ <br/>[test_contract.py:248 -          debug_print() ] Class configuration:
+{&#x27;event_end_since_test_start_s&#x27;: 10,
+ &#x27;event_start_since_test_start_s&#x27;: 5,
  &#x27;payout_time_s&#x27;: 3,
- &#x27;session_start_s&#x27;: 1666745428.7173853}
-[test_contract.py:192 -             app_addr() ] Creating the application...
-[test_contract.py:194 -             app_addr() ] Created app with id: 91 and address: RPNAVZV2XL7Z54ZTZGQMNXYW6A5KNSAXEUJMHQHIEZYOKFZIALNHSK5J3A in tx: D32FEMZO3WNXW736KSHGREPOERWQZDERSYSUMSZGGKI2F6SLCQ6Q
-[test_contract.py:196 -             app_addr() ] Setting up the application...
-[test_contract.py:204 -             app_addr() ] Setup requested with transaction: XC7F4BH3AT5D7RPT34PWXWUELUVKHMPZDII6FHY363UXEXYI5PEQ.
-Current app state: {&#x27;counter_opt_0&#x27;: 0, &#x27;counter_opt_1&#x27;: 0, &#x27;event_timestamp&#x27;: 1666745481, &#x27;bet_amount&#x27;: 140000, &#x27;manager&#x27;: &#x27;d1af02c8440d311f3a418b3dd034d5a0590facbf40c86608517cdb9d350b571b&#x27;, &#x27;winning_count&#x27;: 0, &#x27;oracle_addr&#x27;: &#x27;a7c48a663dc2a3f992e9d43b1ecaf1fafb05b51530e5d4531100d087b1b35d07&#x27;, &#x27;counter_opt_2&#x27;: 0, &#x27;stake_amount&#x27;: 0, &#x27;event_result&#x27;: 99, &#x27;payout_time_window_s&#x27;: 3, &#x27;winning_payout&#x27;: 0}
-[test_contract.py:210 -             app_addr() ] Funded RPNAVZV2XL7Z54ZTZGQMNXYW6A5KNSAXEUJMHQHIEZYOKFZIALNHSK5J3A with 200000microAlgos
-<br/> -------------------------------Captured log setup------------------------------- <br/>DEBUG    test.conftest:test_contract.py:222 Class configuration:
-{&#x27;event_end_since_test_start_s&#x27;: 2,
+ &#x27;session_start_s&#x27;: 1666824631.9362752}
+[test_contract.py:217 -             app_addr() ] Creating the application...
+[test_contract.py:219 -             app_addr() ] Created app with id: 282 and address: UFGHBLU7N4GZ4ATY4BFUKDIMQCUB2MIEBNZ2XMCBBKRT6YHAQPVK7IRY6I in tx: ROV6HCRBWUCLIIRTRI2XTKUZZWSAZVDKHPJBOLSHSEC7PYIAPJBQ
+[test_contract.py:221 -             app_addr() ] Setting up the application...
+[test_contract.py:230 -             app_addr() ] Setup requested with transaction: AXWML4SJNFIVNLYB7L4ZTJYCDDGLMZYUJZH5E66NXG3O5UYKZRAQ.
+Current app state: {&#x27;event_end_timestamp&#x27;: 1666824699, &#x27;oracle_addr&#x27;: &#x27;f4f6dbe4b6ef267f530ae9e1f28462d65940b5f19717d9a4585a65dacc93d5e2&#x27;, &#x27;bet_amount&#x27;: 140000, &#x27;counter_opt_0&#x27;: 0, &#x27;manager&#x27;: &#x27;fde998315d5a659f9e6ff1e73b71842c8fee900e15d32d515d029efdb85b49eb&#x27;, &#x27;event_start_timestamp&#x27;: 1666824694, &#x27;event_result&#x27;: 99, &#x27;payout_time_window_s&#x27;: 3, &#x27;counter_opt_2&#x27;: 0, &#x27;counter_opt_1&#x27;: 0, &#x27;winning_count&#x27;: 0, &#x27;winning_payout&#x27;: 0, &#x27;stake_amount&#x27;: 0}
+[test_contract.py:236 -             app_addr() ] Funded UFGHBLU7N4GZ4ATY4BFUKDIMQCUB2MIEBNZ2XMCBBKRT6YHAQPVK7IRY6I with 200000microAlgos
+<br/> -------------------------------Captured log setup------------------------------- <br/>DEBUG    test.conftest:test_contract.py:248 Class configuration:
+{&#x27;event_end_since_test_start_s&#x27;: 10,
+ &#x27;event_start_since_test_start_s&#x27;: 5,
  &#x27;payout_time_s&#x27;: 3,
- &#x27;session_start_s&#x27;: 1666745428.7173853}
-DEBUG    test.conftest:test_contract.py:192 Creating the application...
-DEBUG    test.conftest:test_contract.py:194 Created app with id: 91 and address: RPNAVZV2XL7Z54ZTZGQMNXYW6A5KNSAXEUJMHQHIEZYOKFZIALNHSK5J3A in tx: D32FEMZO3WNXW736KSHGREPOERWQZDERSYSUMSZGGKI2F6SLCQ6Q
-DEBUG    test.conftest:test_contract.py:196 Setting up the application...
-DEBUG    test.conftest:test_contract.py:204 Setup requested with transaction: XC7F4BH3AT5D7RPT34PWXWUELUVKHMPZDII6FHY363UXEXYI5PEQ.
-Current app state: {&#x27;counter_opt_0&#x27;: 0, &#x27;counter_opt_1&#x27;: 0, &#x27;event_timestamp&#x27;: 1666745481, &#x27;bet_amount&#x27;: 140000, &#x27;manager&#x27;: &#x27;d1af02c8440d311f3a418b3dd034d5a0590facbf40c86608517cdb9d350b571b&#x27;, &#x27;winning_count&#x27;: 0, &#x27;oracle_addr&#x27;: &#x27;a7c48a663dc2a3f992e9d43b1ecaf1fafb05b51530e5d4531100d087b1b35d07&#x27;, &#x27;counter_opt_2&#x27;: 0, &#x27;stake_amount&#x27;: 0, &#x27;event_result&#x27;: 99, &#x27;payout_time_window_s&#x27;: 3, &#x27;winning_payout&#x27;: 0}
-DEBUG    test.conftest:test_contract.py:210 Funded RPNAVZV2XL7Z54ZTZGQMNXYW6A5KNSAXEUJMHQHIEZYOKFZIALNHSK5J3A with 200000microAlgos<br/></div></td></tr></tbody>
+ &#x27;session_start_s&#x27;: 1666824631.9362752}
+DEBUG    test.conftest:test_contract.py:217 Creating the application...
+DEBUG    test.conftest:test_contract.py:219 Created app with id: 282 and address: UFGHBLU7N4GZ4ATY4BFUKDIMQCUB2MIEBNZ2XMCBBKRT6YHAQPVK7IRY6I in tx: ROV6HCRBWUCLIIRTRI2XTKUZZWSAZVDKHPJBOLSHSEC7PYIAPJBQ
+DEBUG    test.conftest:test_contract.py:221 Setting up the application...
+DEBUG    test.conftest:test_contract.py:230 Setup requested with transaction: AXWML4SJNFIVNLYB7L4ZTJYCDDGLMZYUJZH5E66NXG3O5UYKZRAQ.
+Current app state: {&#x27;event_end_timestamp&#x27;: 1666824699, &#x27;oracle_addr&#x27;: &#x27;f4f6dbe4b6ef267f530ae9e1f28462d65940b5f19717d9a4585a65dacc93d5e2&#x27;, &#x27;bet_amount&#x27;: 140000, &#x27;counter_opt_0&#x27;: 0, &#x27;manager&#x27;: &#x27;fde998315d5a659f9e6ff1e73b71842c8fee900e15d32d515d029efdb85b49eb&#x27;, &#x27;event_start_timestamp&#x27;: 1666824694, &#x27;event_result&#x27;: 99, &#x27;payout_time_window_s&#x27;: 3, &#x27;counter_opt_2&#x27;: 0, &#x27;counter_opt_1&#x27;: 0, &#x27;winning_count&#x27;: 0, &#x27;winning_payout&#x27;: 0, &#x27;stake_amount&#x27;: 0}
+DEBUG    test.conftest:test_contract.py:236 Funded UFGHBLU7N4GZ4ATY4BFUKDIMQCUB2MIEBNZ2XMCBBKRT6YHAQPVK7IRY6I with 200000microAlgos<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractNoWinners::test_make_bets</td>
-          <td class="col-duration">0.59</td>
-          <td class="col-time">2022-10-26 00:51:32.356800</td></tr>
+          <td class="col-duration">0.64</td>
+          <td class="col-time">2022-10-26 22:51:50.297891</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -649,18 +630,32 @@ DEBUG    test.conftest:test_contract.py:210 Funded RPNAVZV2XL7Z54ZTZGQMNXYW6A5KN
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractNoWinners::test_oracle_set_result_after_event_end</td>
-          <td class="col-duration">4.46</td>
-          <td class="col-time">2022-10-26 00:51:32.356848</td></tr>
+          <td class="col-duration">12.44</td>
+          <td class="col-time">2022-10-26 22:51:50.297942</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:67 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:67 Waiting for a time in which payout is allowed.<br/></div></td></tr></tbody>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+[test_contract.py:73 - _safe_wait_to_payout() ] Waiting for a time in which payout is allowed.
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.
+DEBUG    test.conftest:test_contract.py:73 Waiting for a time in which payout is allowed.<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractNoWinners::test_request_payout_winners</td>
           <td class="col-duration">0.10</td>
-          <td class="col-time">2022-10-26 00:51:32.356889</td></tr>
+          <td class="col-time">2022-10-26 22:51:50.297982</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -668,8 +663,8 @@ DEBUG    test.conftest:test_contract.py:210 Funded RPNAVZV2XL7Z54ZTZGQMNXYW6A5KN
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_contract.py::TestContractNoWinners::test_request_deletion_after_payout_time</td>
-          <td class="col-duration">3.36</td>
-          <td class="col-time">2022-10-26 00:51:32.356928</td></tr>
+          <td class="col-duration">3.32</td>
+          <td class="col-time">2022-10-26 22:51:50.298032</td></tr>
         <tr>
           <td class="extra" colspan="4">
             <div class="empty log">No log output captured.</div></td></tr></tbody>
@@ -677,22 +672,22 @@ DEBUG    test.conftest:test_contract.py:210 Funded RPNAVZV2XL7Z54ZTZGQMNXYW6A5KN
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_parent.py::TestParentContract::test_creation</td>
-          <td class="col-duration">1.58</td>
-          <td class="col-time">2022-10-26 00:51:32.356978</td></tr>
+          <td class="col-duration">1.50</td>
+          <td class="col-time">2022-10-26 22:51:50.298083</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> -----------------------------Captured stderr setup------------------------------ <br/>[test_parent.py:45 -      parent_app_addr() ] Creating the application...
-[test_parent.py:47 -      parent_app_addr() ] Created parent app with id: 110 and address: 6EGTCADQ3DA5D74Y4NZYF6A3N6AQNRIPAXT57UORTUCR6J2PGDTBE5YXEU in tx: 6V44ZAL6YU6GKQ643OFYWZA6JMJQBGAGPTR5H5QOH4T2LISWUKJQ
-<br/> -------------------------------Captured log setup------------------------------- <br/>DEBUG    test.conftest:test_parent.py:45 Creating the application...
-DEBUG    test.conftest:test_parent.py:47 Created parent app with id: 110 and address: 6EGTCADQ3DA5D74Y4NZYF6A3N6AQNRIPAXT57UORTUCR6J2PGDTBE5YXEU in tx: 6V44ZAL6YU6GKQ643OFYWZA6JMJQBGAGPTR5H5QOH4T2LISWUKJQ<br/></div></td></tr></tbody>
+            <div class="log"> -----------------------------Captured stderr setup------------------------------ <br/>[test_parent.py:36 -      parent_app_addr() ] Creating the application...
+[test_parent.py:38 -      parent_app_addr() ] Created parent app with id: 309 and address: DIXKETLLOKT7FML46PWROORPKUNJJHR3JCCVILHFUZXK24NHK3MWKEGTWQ in tx: VA52BLUXMMNXDOSDAB2AZQ5VJCC55CCJXSSK67FPK6SY3YYMKSIQ
+<br/> -------------------------------Captured log setup------------------------------- <br/>DEBUG    test.conftest:test_parent.py:36 Creating the application...
+DEBUG    test.conftest:test_parent.py:38 Created parent app with id: 309 and address: DIXKETLLOKT7FML46PWROORPKUNJJHR3JCCVILHFUZXK24NHK3MWKEGTWQ in tx: VA52BLUXMMNXDOSDAB2AZQ5VJCC55CCJXSSK67FPK6SY3YYMKSIQ<br/></div></td></tr></tbody>
       <tbody class="passed results-table-row">
         <tr>
           <td class="col-result">Passed</td>
           <td class="col-name">test_parent.py::TestParentContract::test_create_child</td>
-          <td class="col-duration">0.58</td>
-          <td class="col-time">2022-10-26 00:51:32.357034</td></tr>
+          <td class="col-duration">0.62</td>
+          <td class="col-time">2022-10-26 22:51:50.298139</td></tr>
         <tr>
           <td class="extra" colspan="4">
-            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_parent.py:107 -    test_create_child() ] Created child app with id: 113 using account 2GXQFSCEBUYR6OSBRM65ANGVUBMQ7LF7IDEGMCCRPTNZ2NILK4NYI75VAA
-<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_parent.py:107 Created child app with id: 113 using account 2GXQFSCEBUYR6OSBRM65ANGVUBMQ7LF7IDEGMCCRPTNZ2NILK4NYI75VAA<br/> ----------------------------Captured stderr teardown---------------------------- <br/>[conftest.py:85 -        sandbox_setup() ] --sandbox argument provided -&gt; stopping the sandbox...
-<br/> -----------------------------Captured log teardown------------------------------ <br/>INFO     test.conftest:conftest.py:85 --sandbox argument provided -&gt; stopping the sandbox...<br/></div></td></tr></tbody></table></body></html>
+            <div class="log"> ------------------------------Captured stderr call------------------------------ <br/>[test_parent.py:58 -    test_create_child() ] Created child app with id: 312 using account 7XUZQMK5LJSZ7HTP6HTTW4MEFSH65EAOCXJS2UK5AKPP3OC3JHV6HHBQZY
+<br/> -------------------------------Captured log call-------------------------------- <br/>DEBUG    test.conftest:test_parent.py:58 Created child app with id: 312 using account 7XUZQMK5LJSZ7HTP6HTTW4MEFSH65EAOCXJS2UK5AKPP3OC3JHV6HHBQZY<br/> ----------------------------Captured stderr teardown---------------------------- <br/>[conftest.py:89 -        sandbox_setup() ] --sandbox argument not provided -&gt; skipping sandbox teardown...
+<br/> -----------------------------Captured log teardown------------------------------ <br/>INFO     test.conftest:conftest.py:89 --sandbox argument not provided -&gt; skipping sandbox teardown...<br/></div></td></tr></tbody></table></body></html>

--- a/src/test/sandbox-scripts/sandbox_setup.sh
+++ b/src/test/sandbox-scripts/sandbox_setup.sh
@@ -4,7 +4,7 @@ cd src/test/sandbox || exit
 #./sandbox reset
 
 # Create additional_accounts, funding them from the main one
-additional_accounts=4
+additional_accounts=5
 source_addr=$(./sandbox goal account list | awk 'NR==1{print $3}')
 echo "Attempting to create $additional_accounts more accounts, funding them from $source_addr ..."
 

--- a/src/test/test_parent.py
+++ b/src/test/test_parent.py
@@ -72,6 +72,7 @@ class TestParentContract(TestParentContractBase):
         user_app_client.call(
             ChildApp.setup,
             oracle_addr=user_app_client.sender,
-            event_end_unix_timestamp=int(time.time()) + 2,
-            payout_time_window_s=0,
+            event_start_unix_timestamp=int(time.time()) + 30,
+            event_end_unix_timestamp=int(time.time()) + 60,
+            payout_time_window_s=60,
         )


### PR DESCRIPTION
This change implies that the `setup` application call needs a further parameter, named `event_start_unix_timestamp`, which should be the Unix timestamp at which the event is supposed to start.

The smart contract won't allow to place bets after the event it represents has started.